### PR TITLE
Fixed bugs

### DIFF
--- a/preprocessing/preprocess_jetclass.py
+++ b/preprocessing/preprocess_jetclass.py
@@ -9,6 +9,10 @@ from optparse import OptionParser
 def process_and_save(folder_path, n_splits,name):
     # List all files in the folder
     all_files = [os.path.join(folder_path, f) for f in os.listdir(folder_path) if os.path.isfile(os.path.join(folder_path, f))]
+    
+    output_dir = os.path.join(folder_path, name)
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
 
     # Split the files into n_splits
     kf = KFold(n_splits=n_splits)
@@ -49,12 +53,12 @@ if __name__=='__main__':
     (flags, args) = parser.parse_args()
     
 if flags.sample == 'train':
-    process_and_save(os.path.join(flags.folder,'train_100M/'), n_splits=1000,name='train')
+    process_and_save(os.path.join(flags.folder,'train_100M'), n_splits=1000,name='train')
 if flags.sample == 'test':
-    process_and_save(os.path.join(flags.folder,'test_20M', n_splits=200,name='test')
+    process_and_save(os.path.join(flags.folder,'test_20M'), n_splits=200,name='test')
 
 if flags.sample == 'val':
-    process_and_save(os.path.join(flags.folder,'val_5M', n_splits=50,name='val')
+    process_and_save(os.path.join(flags.folder,'val_5M'), n_splits=50,name='val')
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ torch==2.2.2
 torch_cluster==1.6.3
 torch_geometric==2.5.3
 tqdm==4.64.1
-uproot==5.3.3
+#uproot==5.3.3
+uproot==5.3.2
 uproot3==3.14.4
 vector==1.3.1


### PR DESCRIPTION
Dear Dr. Mikuni,
My name is Pradyun Hebbar, I am joining Dr. Nachman's group as a post-bach researcher. My first task is to convert Omnilearn into pytorch during which I noticed a few minor errors with the public omnilearn code.

1.Syntax Error Fix in preprocess_jetclass.py :
Resolved a syntax error in preprocess_jetclass.py caused by an unclosed parenthesis in the os.path.join() function. Also removed the slash while defining the "train_100M" file which caused file path errors.
2.Directory Creation in preprocess_jetclass.py :
Added functionality to create necessary subdirectories ('train', 'test', 'val') within their respective parent folders ('train_100M', 'test_20M', 'val_5M') if they don't already exist. This ensures the script can successfully save processed data files without encountering "No such file or directory" errors.
3.Conflict of versions in requirements.txt :
The file requests uproot==5.3.3 but, coffea 2024.4.1 depends on uproot!=5.3.3 and >=5.3.0. So change it to 5.3.2, and it works fine as of now!
Thank you for your time,
Warm regards,
Pradyun